### PR TITLE
Fix extra bracket on R from less specific name

### DIFF
--- a/xfdcloser-src/data.js
+++ b/xfdcloser-src/data.js
@@ -333,7 +333,7 @@ const rcats = [
 			"R from portmanteau",
 			"R from short name",
 			"R from sort name",
-			"R from less specific name}",
+			"R from less specific name",
 			"R from more specific name",
 			"R from synonym",
 			"R from antonym",


### PR DESCRIPTION
See <https://en.wikipedia.org/wiki/Wikipedia_talk:XFDcloser#RfD_Rcat_R_from_less_specific_name_has_an_extra_closing_curly_bracket>.  Untested.