### PR TITLE
Specify context page title for previews 

### DIFF
--- a/xfdcloser-src/Controllers/ResultPanelController.js
+++ b/xfdcloser-src/Controllers/ResultPanelController.js
@@ -82,6 +82,7 @@ class ResultPanelController {
 			format: "json",
 			formatversion: "2",
 			text: wikitext,
+			title: this.model.discussion.discussionPageName,
 			prop: "text",
 			pst: 1,
 			disablelimitreport: 1,


### PR DESCRIPTION
Resolves the issue https://en.wikipedia.org/wiki/Wikipedia_talk:XFDcloser#Weird_preview_in_close_box

Untested as of now.