### PR TITLE
add unit tests to CI

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,15 @@
+name: Unit Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: npm ci
+    - run: npm test


### PR DESCRIPTION
- automatically run `npm test` for each pull request and commit
- after this is merged, would be nice to rebase all pending patches against this so that unit tests run. Especially the dependabot patches, which could break something by blindly upgrading.