### PR TITLE
`npm run build:dev` should build CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:concat": "concat-cli -f \"core-comment-top.js\" dist/core.min.js \"core-comment-bottom.js\" -o dist/core-gadget.js",
     "build:css": "node bin/concatCss",
     "build": "npm run globals:window && npm run build:loader && npm run lint && npm run test:all && npm run build:css && npm run build:bundle && npm run build:minify && npm run build:concat",
-    "build:dev": "npm run globals:window && npm run build:loader:dev && npm run lint:dev && npm run test:all && npm run build:bundle ",
+    "build:dev": "npm run globals:window && npm run build:loader:dev && npm run lint:dev && npm run test:all && npm run build:css && npm run build:bundle ",
     "build:quickdev": "npm run globals:window && npm run build:loader:dev && npm run build:bundle "
   },
   "author": {


### PR DESCRIPTION
Tried `npm run build:dev` when developing locally, and I was missing CSS files.