### PR TITLE
fix missing xfdcloser links in old skins

### DIFF
--- a/xfdcloser-src/App.js
+++ b/xfdcloser-src/App.js
@@ -66,22 +66,16 @@ import DiscussionView from "./Views/DiscussionView";
 			});
 		});
 	} else {
-		// Initialise show/hide closed discussions tag, unless there is only one discussion on the page
-		const showHide = $("#mw-content-text " + config.xfd.html.head).length > 1 && ShowHideTag.initialiseNewTag();
-		
-		// Set up discussion object for each discussion
-		let headings;
-		switch ( mw.config.get( "skin" ) ) {
-		case "vector":
-		case "vector-2022":
-		case "minerva":
-			headings = config.xfd.html.head + " > span.mw-headline";
-			break;
-		default:
-			headings = config.xfd.html.head;
+		let heading = config.xfd.html.headlineinner.oldskin;
+		if ( [ "vector", "vector-2022", "minerva" ].includes ( mw.config.get( "skin" ) ) ) {
+			heading = config.xfd.html.headlineinner.newskin;
 		}
 
-		$( headings )
+		// Initialise show/hide closed discussions tag, unless there is only one discussion on the page
+		const showHide = $("#mw-content-text " + heading).length > 1 && ShowHideTag.initialiseNewTag();
+		
+		// Set up discussion object for each discussion
+		$( heading )
 			.not(".XFDcloser-ignore")
 			.each(function(index) {
 				try {

--- a/xfdcloser-src/Venue.js
+++ b/xfdcloser-src/Venue.js
@@ -54,7 +54,14 @@ Venue.Mfd = () => new Venue("mfd", {
 	hasIndividualSubpages: true,
 	ns_number:	 null,
 	html: {
-		head:			"h4",
+		headlineouter: {
+			newskin:	"h4",
+			oldskin:	".mw-heading.mw-heading4"
+		},
+		headlineinner: {
+			newskin:	"h4 > .mw-headline",
+			oldskin:	"h4"
+		},
 		list:			"dl",
 		listitem:		"dd"
 	},
@@ -80,7 +87,14 @@ Venue.Cfd = () => {
 		path:		 "Wikipedia:Categories for discussion/Log/",
 		ns_number:	 [14],
 		html: {
-			head:			"h4",
+			headlineouter: {
+				newskin:	"h4",
+				oldskin:	".mw-heading.mw-heading4"
+			},
+			headlineinner: {
+				newskin:	"h4 > .mw-headline",
+				oldskin:	"h4"
+			},
 			list:			"ul",
 			listitem:		"li",
 			nthSpan:		"2"
@@ -130,7 +144,14 @@ Venue.Ffd = () => new Venue("ffd", {
 	ns_number:	 [6],
 	ns_unlink:   ["0", "10", "100", "118"], // main, Template, Portal, Draft
 	html: {
-		head:			"h4",
+		headlineouter: {
+			newskin:	"h4",
+			oldskin:	".mw-heading.mw-heading4"
+		},
+		headlineinner: {
+			newskin:	"h4 > .mw-headline",
+			oldskin:	"h4"
+		},
 		list:			"dl",
 		listitem:		"dd",
 		nthSpan:		"1"
@@ -158,7 +179,14 @@ Venue.Tfd = () => {
 		subpagePath: "Wikipedia:Templates for discussion/",
 		ns_number:	 [10, 828],
 		html: {
-			head:			"h4",
+			headlineouter: {
+				newskin:	"h4",
+				oldskin:	".mw-heading.mw-heading4"
+			},
+			headlineinner: {
+				newskin:	"h4 > .mw-headline",
+				oldskin:	"h4"
+			},
 			list:			"ul",
 			listitem:		"li",
 			nthSpan:		"1"
@@ -235,7 +263,14 @@ Venue.Rfd = () => {
 		path:		 "Wikipedia:Redirects for discussion/Log/",
 		ns_number:	 null,
 		html: {
-			head:			"h4",
+			headlineouter: {
+				newskin:	"h4",
+				oldskin:	".mw-heading.mw-heading4"
+			},
+			headlineinner: {
+				newskin:	"h4 > .mw-headline",
+				oldskin:	"h4"
+			},
 			list:			"ul",
 			listitem:		"li"
 		},
@@ -274,7 +309,14 @@ Venue.Afd = transcludedOnly => new Venue("afd", {
 	ns_logpages: 4, // Wikipedia
 	ns_unlink:   ["0", "10", "100", "118"], // main, Template, Portal, Draft
 	html: {
-		head:			"h3",
+		headlineouter: {
+			newskin:	"h3",
+			oldskin:	".mw-heading.mw-heading3"
+		},
+		headlineinner: {
+			newskin:	"h3 > .mw-headline",
+			oldskin:	"h3"
+		},
 		list:			"dl",
 		listitem:		"dd",
 		nthSpan:		"2"

--- a/xfdcloser-src/Views/DiscussionView.js
+++ b/xfdcloser-src/Views/DiscussionView.js
@@ -181,10 +181,14 @@ DiscussionView.newFromHeadline = function({headingIndex, context, venue, current
 
 	// Find all nodes that are part of this discussion (i.e. excluding subsequent closed discussions)
 	$("table.mw-collapsible").has("div.xfd-closed").addClass("xfd-closed");	// Fix for closed discussion within a collapsed table (e.g. MfD)
-	const $discussionNodes = $heading.nextUntil(venue.html.head + ", div.xfd-closed, table.xfd-closed");
+	let headlineouter = venue.html.headlineouter.oldskin;
+	if ( [ "vector", "vector-2022", "minerva" ].includes ( mw.config.get( "skin" ) ) ) {
+		headlineouter = venue.html.headlineouter.newskin;
+	}
+	const $discussionNodes = $heading.nextUntil(headlineouter + ", div.xfd-closed, table.xfd-closed");
 	$discussionNodes.addClass(`${id}-discussion-node`);
 
-	// Get list of nominated pages. Also the proposed action for CfD. 
+	// Get list of nominated pages. Also the proposed action for CfD.
 	let pages = [];
 	let action = "";
 	if (venue.type === "cfd") {


### PR DESCRIPTION
fix #54 headings sometimes incorrectly marked as closed on old skins (discussionText being read incorrectly)