### PR TITLE
fix missing links in vector-2022 and minerva

### DIFF
--- a/xfdcloser-src/App.js
+++ b/xfdcloser-src/App.js
@@ -66,10 +66,7 @@ import DiscussionView from "./Views/DiscussionView";
 			});
 		});
 	} else {
-		let heading = config.xfd.html.headlineinner.oldskin;
-		if ( [ "vector-2022", "minerva" ].includes ( mw.config.get( "skin" ) ) ) {
-			heading = config.xfd.html.headlineinner.newskin;
-		}
+		const heading = config.xfd.html.headlineinner;
 
 		// Initialise show/hide closed discussions tag, unless there is only one discussion on the page
 		const showHide = $("#mw-content-text " + heading).length > 1 && ShowHideTag.initialiseNewTag();

--- a/xfdcloser-src/Venue.js
+++ b/xfdcloser-src/Venue.js
@@ -54,14 +54,8 @@ Venue.Mfd = () => new Venue("mfd", {
 	hasIndividualSubpages: true,
 	ns_number:	 null,
 	html: {
-		headlineouter: {
-			newskin:	"h4",
-			oldskin:	".mw-heading.mw-heading4"
-		},
-		headlineinner: {
-			newskin:	"h4 > .mw-headline",
-			oldskin:	"h4"
-		},
+		headlineouter:	".mw-heading.mw-heading4",
+		headlineinner:	"h4",
 		list:			"dl",
 		listitem:		"dd"
 	},
@@ -87,14 +81,8 @@ Venue.Cfd = () => {
 		path:		 "Wikipedia:Categories for discussion/Log/",
 		ns_number:	 [14],
 		html: {
-			headlineouter: {
-				newskin:	"h4",
-				oldskin:	".mw-heading.mw-heading4"
-			},
-			headlineinner: {
-				newskin:	"h4 > .mw-headline",
-				oldskin:	"h4"
-			},
+			headlineouter:	".mw-heading.mw-heading4",
+			headlineinner:	"h4",
 			list:			"ul",
 			listitem:		"li",
 			nthSpan:		"2"
@@ -144,14 +132,8 @@ Venue.Ffd = () => new Venue("ffd", {
 	ns_number:	 [6],
 	ns_unlink:   ["0", "10", "100", "118"], // main, Template, Portal, Draft
 	html: {
-		headlineouter: {
-			newskin:	"h4",
-			oldskin:	".mw-heading.mw-heading4"
-		},
-		headlineinner: {
-			newskin:	"h4 > .mw-headline",
-			oldskin:	"h4"
-		},
+		headlineouter:	".mw-heading.mw-heading4",
+		headlineinner:	"h4",
 		list:			"dl",
 		listitem:		"dd",
 		nthSpan:		"1"
@@ -179,14 +161,8 @@ Venue.Tfd = () => {
 		subpagePath: "Wikipedia:Templates for discussion/",
 		ns_number:	 [10, 828],
 		html: {
-			headlineouter: {
-				newskin:	"h4",
-				oldskin:	".mw-heading.mw-heading4"
-			},
-			headlineinner: {
-				newskin:	"h4 > .mw-headline",
-				oldskin:	"h4"
-			},
+			headlineouter:	".mw-heading.mw-heading4",
+			headlineinner:	"h4",
 			list:			"ul",
 			listitem:		"li",
 			nthSpan:		"1"
@@ -263,14 +239,8 @@ Venue.Rfd = () => {
 		path:		 "Wikipedia:Redirects for discussion/Log/",
 		ns_number:	 null,
 		html: {
-			headlineouter: {
-				newskin:	"h4",
-				oldskin:	".mw-heading.mw-heading4"
-			},
-			headlineinner: {
-				newskin:	"h4 > .mw-headline",
-				oldskin:	"h4"
-			},
+			headlineouter:	".mw-heading.mw-heading4",
+			headlineinner:	"h4",
 			list:			"ul",
 			listitem:		"li"
 		},
@@ -309,14 +279,8 @@ Venue.Afd = transcludedOnly => new Venue("afd", {
 	ns_logpages: 4, // Wikipedia
 	ns_unlink:   ["0", "10", "100", "118"], // main, Template, Portal, Draft
 	html: {
-		headlineouter: {
-			newskin:	"h3",
-			oldskin:	".mw-heading.mw-heading3"
-		},
-		headlineinner: {
-			newskin:	"h3 > .mw-headline",
-			oldskin:	"h3"
-		},
+		headlineouter:	".mw-heading.mw-heading3",
+		headlineinner:	"h3",
 		list:			"dl",
 		listitem:		"dd",
 		nthSpan:		"2"

--- a/xfdcloser-src/Views/DiscussionView.js
+++ b/xfdcloser-src/Views/DiscussionView.js
@@ -181,10 +181,7 @@ DiscussionView.newFromHeadline = function({headingIndex, context, venue, current
 
 	// Find all nodes that are part of this discussion (i.e. excluding subsequent closed discussions)
 	$("table.mw-collapsible").has("div.xfd-closed").addClass("xfd-closed");	// Fix for closed discussion within a collapsed table (e.g. MfD)
-	let headlineouter = venue.html.headlineouter.oldskin;
-	if ( [ "vector-2022", "minerva" ].includes ( mw.config.get( "skin" ) ) ) {
-		headlineouter = venue.html.headlineouter.newskin;
-	}
+	const headlineouter = venue.html.headlineouter;
 	const $discussionNodes = $heading.nextUntil(headlineouter + ", div.xfd-closed, table.xfd-closed");
 	$discussionNodes.addClass(`${id}-discussion-node`);
 


### PR DESCRIPTION
- fix missing links in vector-2022 and minerva skins
- simplify code now that we don't have to support 2 kinds of headings. (https://www.mediawiki.org/wiki/Heading_HTML_changes is now complete)