### PR TITLE
feat: strip noinclude tags when removing AfD nominations

### DIFF
--- a/test/testTaskRemoveNomTemplates.js
+++ b/test/testTaskRemoveNomTemplates.js
@@ -63,10 +63,12 @@ describe("RemoveNomTemplates", function() {
 	it("transforms a page with a nom templatge", function() {
 		const transformed = RemoveNomTemplates.transform(task, {
 			title: "Foo",
-			content: `<!-- Please do not remove or change this AfD message until the discussion has been closed. -->
+			content: `<noinclude>
+<!-- Please do not remove or change this AfD message until the discussion has been closed. -->
 {{Article for deletion/dated|page=Foo|timestamp=20200617061910|year=2020|month=June|day=17|substed=yes|help=off}}
 <!-- Once discussion is closed, please place on talk page: {{Old AfD multi|page=Foo|date=17 June 2020|result='''keep'''}} -->
 <!-- End of AfD message, feel free to edit beyond this point -->
+</noinclude>
 Lorem impsum`
 		});
 		if ( transformed.then ) {

--- a/xfdcloser-src/Venue.js
+++ b/xfdcloser-src/Venue.js
@@ -293,7 +293,7 @@ Venue.Afd = transcludedOnly => new Venue("afd", {
 		alreadyClosed:	"<!--Template:Afd bottom-->"		
 	},
 	regex: {
-		nomTemplate:	/(?:{{[Aa](?:rticle for deletion\/dated|fDM|fd\/dated)|<!-- Please do not remove or change this AfD message)(?:.|\n)*?}}(?:(?:.|\n)+this point -->)?\s*/g
+		nomTemplate:	/(<noinclude>[\n\s]*)?(?:{{[Aa](?:rticle for deletion\/dated|fDM|fd\/dated)|<!-- Please do not remove or change this AfD message)(?:.|\n)*?}}(?:(?:.|\n)+this point -->)?([\n\s]*<\/noinclude>)?\s*/g
 	},
 	transcludedOnly:	transcludedOnly,
 	relistTasks:		["UpdateDiscussion", "UpdateOldLogPage", "UpdateNewLogPage"]


### PR DESCRIPTION
This PR improves the regex for AfD nomination removals in order to strip `noinclude` tags that are sometimes added during nomination. These are currently left and leaves extra work to remove them, as seen in [`1288284815`](https://en.wikipedia.org/wiki/Special:Diff/1288284815)