### PR TITLE
deploy: add a `--quick` mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,22 +68,20 @@ On-wiki testing is conducted at the [Test Wikipedia](https://test.wikipedia.org/
 6. Run `node bin/server` in a terminal (in the directory where your local repistory is located).
 7. Now when you visit the XFD log/discussion pages, the most recently built version of the script will be loaded.
 
-### Testing deployment
+### Deploying to testwiki
 1. Comment out or remove the code that loads the development version from [your common.js](https://test.wikipedia.org/wiki/Special:MyPage/common.js)
 2. Ensure the XFDcloser gadget is enabled in your preferences.
 3. Deploy to testwiki (see "Repository structure" section above for what goes where)
 4. Set up mock XFD discussions. A development version of Twinkle is available as a gadget, and can be used to nominate pages for deletion.
 5. Now when you visit the XFD log/discussion pages, the testwiki gadget with the files you deployed will be loaded.
 
-## Deployment
+## Deploying to enwiki
 As XFDcloser is a gadget, you must have interface-admin rights to deploy to the wiki.
 1. Ensure:
    - changes are committed and merged to master branch of the GitHub repo
    - you are currently on the master branch, and synced with GitHub repo
-2. Bump the version number. See the comments in the `bin\version.js` file for how to do this from the terminal.
-3. Commit the version change, and push/sync to GitHub repo
-4. Run a full build: run `npm run build` in terminal
-5. You are now ready to deploy: see the comments in the `bin\deploy.js` file for how to do this from the terminal.
+2. Create a bin/credentials.json file, following the format specified in bin/credentials.example.json
+3. `npm run deploy`. This will deploy both the beta version and the non-beta version, ensuring that both users of the gadget receive the latest updates.
 
 ## Planned features
 A general overview of planned features:

--- a/bin/credentials.example.json
+++ b/bin/credentials.example.json
@@ -1,0 +1,4 @@
+{
+	"username": "User name@Bot task",
+	"password": "Password"
+}

--- a/bin/deploy.js
+++ b/bin/deploy.js
@@ -50,48 +50,86 @@ function logError(error) {
 	);
 }
 
-// Prompt user for info
-const wiki = prompt("> Wikipedia subdomain: ");
-const beta = prompt("> Beta deployment [Y/n]: ");
-const isBeta = beta.trim().toUpperCase() !== "N";
-console.log(`Targeting ${isBeta ? "BETA" : "MAIN"} version of script.`);
-const message = prompt("> Edit summary message (optional): ");
+// Check for --quick parameter. Quick mode deploys to both enwiki and enwiki-beta, without prompting for any info
+const quick = process.argv.includes("--quick");
+const config = [];
 
-// Extract info for edit summary.
-const version = require("../package.json").version;
-const sha = execSync("git rev-parse --short HEAD").toString("utf8").trim();
-const editSummary = `v${version} at ${sha}: ${message || "Updated from repository"}`;
-console.log(`Edit summary is: "${editSummary}"`);
+if (quick) {
+	config.push({
+		wiki: "en",
+		beta: "n",
+		userComment: "",
+		consoleMessage: "QUICK MODE: Using defaults (en, beta, blank edit summary, auto-continue)"
+	});
+	config.push({
+		wiki: "en",
+		beta: "n",
+		userComment: "",
+		consoleMessage: "QUICK MODE: Using defaults (en, main, blank edit summary, auto-continue)"
+	});
+} else {
+	// Prompt user for info
+	wiki = prompt("> Wikipedia subdomain: ");
+	beta = prompt("> Beta deployment [Y/n]: ");
+	userComment = prompt("> Edit summary message (optional): ");
+	config.push({
+		wiki: wiki,
+		beta: beta,
+		userComment: userComment,
+		consoleMessage: null
+	});
 
-const deployments = [
-	{file: "loader-gadget.js", target: "MediaWiki:Gadget-XFDcloser.js"},
-	{file: "core-gadget.js", target: `MediaWiki:Gadget-XFDcloser-core${isBeta ? "-beta" : ""}.js`},
-	{file: "styles-gadget.css", target: `MediaWiki:Gadget-XFDcloser-core${isBeta ? "-beta" : ""}.css`}
-];
+}
 
-const api = new mwn({
-	apiUrl: `https://${wiki}.wikipedia.org/w/api.php`,
-	username: username,
-	password: password
-});
+for ( let i = 0; i < config.length; i++ ) {
+	const wiki = config[i].wiki;
+	const beta = config[i].beta;
+	const userComment = config[i].userComment;
+	const consoleMessage = config[i].consoleMessage;
 
-console.log(`... logging in as ${username}  ...`);
-api.loginGetToken().then(() => {
-	prompt("> Press [Enter] to start deploying or [ctrl + C] to cancel");
-	console.log("--- starting deployment ---");
-	const editPromises = deployments.map(deployment => {
-		let content = fs.readFileSync("./dist/"+deployment.file, "utf8").toString();
-		return api.save(deployment.target, content, editSummary).then((response) => {
-			const status = response && response.nochange
-				? "━ No change saving"
-				: "✔ Successfully saved";
-			console.log(`${status} ${deployment.file} to ${wiki}:${deployment.target}`);
-		}, (error) => {
-			console.log(`✘ Failed to save ${deployment.file} to ${wiki}:${deployment.target}`);
-			logError(error);
+	if ( consoleMessage ) {
+		console.log(consoleMessage);
+	}
+
+	// Extract info for edit summary.
+	const version = require("../package.json").version;
+	const sha = execSync("git rev-parse --short HEAD").toString("utf8").trim();
+	const editSummary = `v${version} at ${sha}: ${userComment || "Updated from repository"}`;
+	console.log(`Edit summary is: "${editSummary}"`);
+
+	const isBeta = beta.trim().toUpperCase() !== "N";
+	const deployments = [
+		{file: "loader-gadget.js", target: "MediaWiki:Gadget-XFDcloser.js"},
+		{file: "core-gadget.js", target: `MediaWiki:Gadget-XFDcloser-core${isBeta ? "-beta" : ""}.js`},
+		{file: "styles-gadget.css", target: `MediaWiki:Gadget-XFDcloser-core${isBeta ? "-beta" : ""}.css`}
+	];
+
+	const api = new mwn({
+		apiUrl: `https://${wiki}.wikipedia.org/w/api.php`,
+		username: username,
+		password: password
+	});
+
+	console.log(`... logging in as ${username}  ...`);
+	api.loginGetToken().then(() => {
+		if (!quick) {
+			prompt("> Press [Enter] to start deploying or [ctrl + C] to cancel");
+		}
+		console.log("--- starting deployment ---");
+		const editPromises = deployments.map(deployment => {
+			let content = fs.readFileSync("./dist/"+deployment.file, "utf8").toString();
+			return api.save(deployment.target, content, editSummary).then((response) => {
+				const status = response && response.nochange
+					? "━ No change saving"
+					: "✔ Successfully saved";
+				console.log(`${status} ${deployment.file} to ${wiki}:${deployment.target}`);
+			}, (error) => {
+				console.log(`✘ Failed to save ${deployment.file} to ${wiki}:${deployment.target}`);
+				logError(error);
+			});
 		});
-	});
-	Promise.all(editPromises).then(() => {
-		console.log("--- end of deployment ---");
-	});
-}).catch(logError);
+		Promise.all(editPromises).then(() => {
+			console.log("--- end of deployment ---");
+		});
+	}).catch(logError);
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:minify": "uglifyjs dist/core.js --compress -b ascii_only=true,beautify=false --output dist/core.min.js",
     "build:quickdev": "npm run globals:window && npm run build:loader:dev && npm run build:bundle ",
     "build": "npm run globals:window && npm run build:loader && npm run lint && npm run test:all && npm run build:css && npm run build:bundle && npm run build:minify && npm run build:concat",
-    "deploy": "node bin/deploy.js --quick",
+    "deploy": "npm run build && node bin/deploy.js --quick",
     "globals:node": "concat-cli -f \"globals-src/comment.js\" \"globals-src/node.js\" -o \"globals.js\"",
     "globals:window": "concat-cli -f \"globals-src/comment.js\" \"globals-src/window.js\" -o \"globals.js\"",
     "lint:bin:fix": "eslint \"bin/*.js\" --fix --env node",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:minify": "uglifyjs dist/core.js --compress -b ascii_only=true,beautify=false --output dist/core.min.js",
     "build:quickdev": "npm run globals:window && npm run build:loader:dev && npm run build:bundle ",
     "build": "npm run globals:window && npm run build:loader && npm run lint && npm run test:all && npm run build:css && npm run build:bundle && npm run build:minify && npm run build:concat",
-    "deploy": "node bin/deploy.js",
+    "deploy": "node bin/deploy.js --quick",
     "globals:node": "concat-cli -f \"globals-src/comment.js\" \"globals-src/node.js\" -o \"globals.js\"",
     "globals:window": "concat-cli -f \"globals-src/comment.js\" \"globals-src/window.js\" -o \"globals.js\"",
     "lint:bin:fix": "eslint \"bin/*.js\" --fix --env node",


### PR DESCRIPTION
- `--quick` deploys both beta and main at the same time
- `--quick` deploys with no user input collected / no pauses
- converted promises to async, so that command line stuff runs sequentially instead of getting jumbled together
- changed `npm run deploy` to use `--quick` mode
- updated readme
- removed mention of bumping version from readme, to simplify the deploy process
- added example credentials file