### PR TITLE
Skip on "Removing link(s) undefined (XFDcloser)" edit summaries

### DIFF
--- a/xfdcloser-src/Controllers/TaskItemController.js
+++ b/xfdcloser-src/Controllers/TaskItemController.js
@@ -132,6 +132,10 @@ class TaskItemController {
 			this.model.addWarning(`${makeLink(title)} skipped (no direct links)`);
 			this.model.trackStep("skipped");
 			break;
+    case "noDiscussionPageLink":
+			this.model.addError(`No discussion page link found on page ${makeLink(title)}`);
+			this.model.trackStep("skipped");
+			break;
 		case "noChangesMade":
 			this.model.addError(`Did not find any changes to make to ${makeLink(title)}`);
 			this.model.trackStep("skipped");

--- a/xfdcloser-src/Controllers/Tasks/UnlinkBacklinks.js
+++ b/xfdcloser-src/Controllers/Tasks/UnlinkBacklinks.js
@@ -146,6 +146,9 @@ export default class  UnlinkBacklinks extends TaskItemController {
 		if ( newWikitext === page.content ) {
 			return rejection("skippedNoLinks");
 		}
+    if ( !this.model.discussion.discussionPageLink ) {
+      return rejection("noDiscussionPageLink");
+    }
 		return this.processListItems(page.title, newWikitext)
 			.then((updatedWikitext, isMajorEdit) => {
 				const prefix = "Removing link(s)" +


### PR DESCRIPTION
Adds a new check to skip on edit summaries where the discussionPageLink is undefined. This prevents edit summaries like this: https://en.wikipedia.org/wiki/Special:Diff/1313214518

Open to a better fix if possible, but for now the reason / root cause isn't known. For context, see [User talk:Explicit/Archive 59#"Removing link(s) undefined (XFDcloser)"](https://en.wikipedia.org/wiki/User_talk:Explicit/Archive_59#"Removing_link(s)_undefined_(XFDcloser)").